### PR TITLE
Failing test case: Enable "active_support/string/conversions"

### DIFF
--- a/lib/rails_legit/verify_date_validator.rb
+++ b/lib/rails_legit/verify_date_validator.rb
@@ -78,7 +78,7 @@ module RailsLegit
 
     def try_to_convert_to_date(arg)
       if arg.respond_to? :to_date
-        arg.to_date
+        arg.to_date rescue false
       else
         begin
           Date.parse(arg.to_s)

--- a/spec/support/date.rb
+++ b/spec/support/date.rb
@@ -1,4 +1,5 @@
 require "active_model"
+require "active_support/core_ext/string/conversions"
 
 shared_examples "basic date validations" do
 


### PR DESCRIPTION
Description: ActiveSupport string conversion adds a `to_date` method to **all** string objects. And when called, raises an exception when the date is invalid. So merely checking `respond_to?(:to_date)` is not enough. We need to ignore the invalid cases by considering them as `false` (could not convert)
