### PR TITLE
Make .gemspec simpler

### DIFF
--- a/rails_legit.gemspec
+++ b/rails_legit.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-  spec.files         = Dir.glob('lib/**/*') + ['Rakefile', 'README.md', 'LICENSE.txt']
+  spec.files         = `git ls-files lib`.split($/) + ['Rakefile', 'README.md', 'LICENSE.txt']
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/rails_legit.gemspec
+++ b/rails_legit.gemspec
@@ -13,9 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = Dir.glob('lib/**/*') + ['Rakefile', 'README.md', 'LICENSE.txt']
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
- Remove tests related files from the gemspec so that a user installing
  the gem won't download them when doing `gem install rails_legit`.
